### PR TITLE
chore(ci): migrated default.yaml from `javascript.yaml` to `yarn-library.yaml`

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   default:
-    uses: 'rios0rios0/pipelines/.github/workflows/javascript.yaml@main'
+    uses: 'rios0rios0/pipelines/.github/workflows/yarn-library.yaml@main'


### PR DESCRIPTION
## Summary

Switched the reusable workflow reference from `rios0rios0/pipelines/.github/workflows/javascript.yaml@main` to `rios0rios0/pipelines/.github/workflows/yarn-library.yaml@main`.

## Why

`javascript.yaml` does not exist in the pipelines repo (the workflow run was failing at workflow-load with `workflow file issue`). The new `yarn-library.yaml` calls the same validation under the hood and adds the `delivery-release` job, so future bumps will tag automatically.

Part of the broader migration tracked in https://github.com/rios0rios0/pipelines/pull/387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
