### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,7 +104,7 @@ yarn test              # ~5-10 s
 
 ## CI/CD Pipeline
 
-The workflow file `.github/workflows/default.yaml` delegates all steps to the shared reusable workflow at `rios0rios0/pipelines/.github/workflows/javascript.yaml@main`.
+The workflow file `.github/workflows/default.yaml` delegates all steps to the shared reusable workflow at `rios0rios0/pipelines/.github/workflows/yarn-library.yaml@main`.
 
 Triggers:
 - Push to `main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to fix CI reusable workflow name (`javascript.yaml` → `yarn-library.yaml`)
+
 ## [0.2.0] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,4 +37,4 @@ Single command: `scaled start <service> [--build] [--containers <n>] [--set-env 
 
 ## CI
 
-`.github/workflows/default.yaml` delegates to `rios0rios0/pipelines/.github/workflows/javascript.yaml@main`. Triggers on push to `main`, tags, PRs to `main`, and manual dispatch.
+`.github/workflows/default.yaml` delegates to `rios0rios0/pipelines/.github/workflows/yarn-library.yaml@main`. Triggers on push to `main`, tags, PRs to `main`, and manual dispatch.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.