### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,7 @@ yarn test              # ~5-10 s
 ## Architecture and Design Patterns
 
 - **Domain-Driven Design (DDD):** Code is split into `domain/` (entities, repository & service contracts) and `infrastructure/` (concrete implementations). This keeps business logic decoupled from I/O.
-- **Strategy pattern:** `src/resolver/strategy/` contains pluggable execution strategies (e.g. running tools locally vs. remotely).
+- **Strategy pattern:** `src/resolver/strategy/` contains pluggable service resolvers behind `ResolverInterface`; only `LocalResolver` (local-filesystem lookup) is implemented so far.
 - **Service Builder:** `src/resolver/service-builder.ts` constructs `ServiceDefinition` objects which carry the name and file-system path of a tool.
 - **Listr task lists:** Long-running operations are presented as an ordered list of observable tasks in the terminal.
 - **Docker-first tool execution:** Each supported scanner (Nmap, Nikto, SQLMap) has its own `docker-compose.yml` under `tools/`, ensuring isolated and reproducible runs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to correct the strategy-pattern description (only `LocalResolver` ships; there is no remote strategy)
+
 ## [0.2.1] - 2026-05-19
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ yarn test                 # mocha + nyc coverage
 TypeScript CLI built on oclif v1 (`@oclif/command`). Orchestrates security scanners (Nmap, Nikto, SQLMap) via Docker Compose.
 
 - **DDD layout**: `src/domain/` holds entities, repository contracts, and service interfaces. `src/infrastructure/` has concrete implementations. Business logic stays decoupled from I/O.
-- **Strategy pattern**: `src/resolver/strategy/` provides pluggable execution strategies (local vs. remote).
+- **Strategy pattern**: `src/resolver/strategy/` holds pluggable service resolvers behind `ResolverInterface`; only `LocalResolver` (local-filesystem lookup under `tools/`) is implemented today.
 - **Service builder**: `src/resolver/service-builder.ts` constructs `ServiceDefinition` objects (name + path to a tool directory under `tools/`).
 - **Manager**: `src/manager/` handles the start → report → stop lifecycle via Listr task lists.
 - **Docker-first**: each scanner lives under `tools/<name>/` with its own `docker-compose.yml`.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.