### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,9 +41,9 @@ src/
   types.ts                # Shared TypeScript types (ServiceDefinition, NMAPReport, …)
 tools/
   nmap/
-    docker-compose.yml    # Dockerised Nmap configuration
-  nikto/                  # Dockerised Nikto configuration
-  sqlmap/                 # Dockerised SQLMap configuration
+    docker-compose.yml    # Dockerised Nmap configuration (Dockerfile + entrypoint.sh)
+  nikto/                  # empty placeholder (.gitkeep only — not yet implemented)
+  sqlmap/                 # empty placeholder (.gitkeep only — not yet implemented)
 ```
 
 ---
@@ -98,7 +98,7 @@ yarn test              # ~5-10 s
 - **Strategy pattern:** `src/resolver/strategy/` contains pluggable service resolvers behind `ResolverInterface`; only `LocalResolver` (local-filesystem lookup) is implemented so far.
 - **Service Builder:** `src/resolver/service-builder.ts` constructs `ServiceDefinition` objects which carry the name and file-system path of a tool.
 - **Listr task lists:** Long-running operations are presented as an ordered list of observable tasks in the terminal.
-- **Docker-first tool execution:** Each supported scanner (Nmap, Nikto, SQLMap) has its own `docker-compose.yml` under `tools/`, ensuring isolated and reproducible runs.
+- **Docker-first tool execution:** A scanner is defined by `tools/<name>/docker-compose.yml`. Only `nmap` ships one today; `nikto` and `sqlmap` are empty placeholders. `LocalResolver` resolves a service only when that compose file exists, so `scaled start nikto` / `sqlmap` fail with "Service not found" until they are implemented. Report parsing is likewise Nmap-only (`NMAPReportService` is the sole implementation).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to correct the Docker-first claim: only `tools/nmap/` has a `docker-compose.yml`, while `tools/nikto/` and `tools/sqlmap/` are empty placeholders, so only `nmap` is runnable today
+
 ## [0.2.2] - 2026-06-22
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ TypeScript CLI built on oclif v1 (`@oclif/command`). Orchestrates security scann
 - **Strategy pattern**: `src/resolver/strategy/` holds pluggable service resolvers behind `ResolverInterface`; only `LocalResolver` (local-filesystem lookup under `tools/`) is implemented today.
 - **Service builder**: `src/resolver/service-builder.ts` constructs `ServiceDefinition` objects (name + path to a tool directory under `tools/`).
 - **Manager**: `src/manager/` handles the start → report → stop lifecycle via Listr task lists.
-- **Docker-first**: each scanner lives under `tools/<name>/` with its own `docker-compose.yml`.
+- **Docker-first**: each scanner lives under `tools/<name>/` with its own `docker-compose.yml`. Only `nmap` is populated today — `tools/nikto/` and `tools/sqlmap/` are empty placeholders. `LocalResolver` resolves a service only when `tools/<name>/docker-compose.yml` exists, so `scaled start nikto` / `sqlmap` currently fail with "Service not found".
 
 Single command: `scaled start <service> [--build] [--containers <n>] [--set-env KEY=VALUE]`.
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.